### PR TITLE
Fix inadvertent removal of error handling in last PR

### DIFF
--- a/eppn.py
+++ b/eppn.py
@@ -92,11 +92,14 @@ def add_eppn(config, service):
         page_token = resp.get('nextPageToken', None)
         if users:
             for user in users:
-                if not user['customSchemas'][config['schema_name']]['eduPersonPrincipalName'].lower().split("@")[0]:
+                try:
+                    if not user['customSchemas'][config['schema_name']]['eduPersonPrincipalName'].lower().split("@")[0]:
+                        no_eppn.append(user['id'])
+                    else:
+                        if high_eppn < user['customSchemas'][config['schema_name']]['eduPersonPrincipalName'].lower().split("@")[0]:
+                            high_eppn = user['customSchemas'][config['schema_name']]['eduPersonPrincipalName'].lower().split("@")[0]
+                except KeyError:
                     no_eppn.append(user['id'])
-                else:
-                    if high_eppn < user['customSchemas'][config['schema_name']]['eduPersonPrincipalName'].lower().split("@")[0]:
-                        high_eppn = user['customSchemas'][config['schema_name']]['eduPersonPrincipalName'].lower().split("@")[0]
 
         if page_token is None:
             break


### PR DESCRIPTION
In PR #1, I accidentally removed the error handling for key errors, which worked at the time in my testing but I've since realized it probably doesn't for a lot of use cases.

It is now back. :)